### PR TITLE
Add task 1 functions and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,8 +126,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# IDEA
+# editors
 .idea
+.vscode
 
 # LaTeX
 *.aux

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -1,1 +1,0 @@
-print("import sources directory")

--- a/project/__main__.py
+++ b/project/__main__.py
@@ -1,1 +1,0 @@
-print("exec sources directory")

--- a/project/simple_graph_funcs.py
+++ b/project/simple_graph_funcs.py
@@ -1,13 +1,13 @@
 import cfpq_data
 from networkx.drawing import nx_pydot
 
-def get_graph_info(graph_name: str) -> tuple[int, int, list[str]]:
+def get_graph_info(graph_name: str) -> tuple[int, int, set[str]]:
     graph_path = cfpq_data.download(graph_name)
     graph = cfpq_data.graph_from_csv(graph_path)
 
     labels = {data["label"] for _, _, data in graph.edges(data=True)}
 
-    return graph.number_of_nodes(), graph.number_of_edges(), sorted(labels)
+    return graph.number_of_nodes(), graph.number_of_edges(), labels
 
 def create_and_save_two_cycled_graph(n: int, m: int, labels: tuple[str, str], file_path: str) -> None:
     graph = cfpq_data.labeled_two_cycles_graph(n, m, labels=labels)

--- a/project/simple_graph_funcs.py
+++ b/project/simple_graph_funcs.py
@@ -1,12 +1,21 @@
 import cfpq_data
 from networkx.drawing import nx_pydot
 
+
 def get_graph_info(graph_name: str) -> tuple[int, int, list[str]]:
     graph_path = cfpq_data.download(graph_name)
     graph = cfpq_data.graph_from_csv(graph_path)
-    return graph.number_of_nodes(), graph.number_of_edges(), cfpq_data.get_sorted_labels(graph)
 
-def create_and_save_two_cycled_graph(n: int, m: int, labels: tuple[str, str], file_path: str) -> None:
+    nnodes = graph.number_of_nodes()
+    nedges = graph.number_of_edges()
+    labels = cfpq_data.get_sorted_labels(graph)
+
+    return nnodes, nedges, labels
+
+
+def create_and_save_two_cycled_graph(
+    n: int, m: int, labels: tuple[str, str], file_path: str
+) -> None:
     graph = cfpq_data.labeled_two_cycles_graph(n, m, labels=labels)
     pydot_graph = nx_pydot.to_pydot(graph)
     pydot_graph.write_raw(file_path)

--- a/project/simple_graph_funcs.py
+++ b/project/simple_graph_funcs.py
@@ -1,13 +1,10 @@
 import cfpq_data
 from networkx.drawing import nx_pydot
 
-def get_graph_info(graph_name: str) -> tuple[int, int, set[str]]:
+def get_graph_info(graph_name: str) -> tuple[int, int, list[str]]:
     graph_path = cfpq_data.download(graph_name)
     graph = cfpq_data.graph_from_csv(graph_path)
-
-    labels = {data["label"] for _, _, data in graph.edges(data=True)}
-
-    return graph.number_of_nodes(), graph.number_of_edges(), labels
+    return graph.number_of_nodes(), graph.number_of_edges(), cfpq_data.get_sorted_labels(graph)
 
 def create_and_save_two_cycled_graph(n: int, m: int, labels: tuple[str, str], file_path: str) -> None:
     graph = cfpq_data.labeled_two_cycles_graph(n, m, labels=labels)

--- a/project/simple_graph_funcs.py
+++ b/project/simple_graph_funcs.py
@@ -1,0 +1,15 @@
+import cfpq_data
+from networkx.drawing import nx_pydot
+
+def get_graph_info(graph_name: str) -> tuple[int, int, list[str]]:
+    graph_path = cfpq_data.download(graph_name)
+    graph = cfpq_data.graph_from_csv(graph_path)
+
+    labels = {data["label"] for _, _, data in graph.edges(data=True)}
+
+    return graph.number_of_nodes(), graph.number_of_edges(), sorted(labels)
+
+def create_and_save_two_cycled_graph(n: int, m: int, labels: tuple[str, str], file_path: str) -> None:
+    graph = cfpq_data.labeled_two_cycles_graph(n, m, labels)
+    pydot_graph = nx_pydot.to_pydot(graph)
+    pydot_graph.write_raw(file_path)

--- a/project/simple_graph_funcs.py
+++ b/project/simple_graph_funcs.py
@@ -10,6 +10,6 @@ def get_graph_info(graph_name: str) -> tuple[int, int, list[str]]:
     return graph.number_of_nodes(), graph.number_of_edges(), sorted(labels)
 
 def create_and_save_two_cycled_graph(n: int, m: int, labels: tuple[str, str], file_path: str) -> None:
-    graph = cfpq_data.labeled_two_cycles_graph(n, m, labels)
+    graph = cfpq_data.labeled_two_cycles_graph(n, m, labels=labels)
     pydot_graph = nx_pydot.to_pydot(graph)
     pydot_graph.write_raw(file_path)

--- a/tests/test_simple_graph_funcs.py
+++ b/tests/test_simple_graph_funcs.py
@@ -5,10 +5,9 @@ from project.simple_graph_funcs import get_graph_info, create_and_save_two_cycle
 
 def test_get_graph_info():
     nodes, edges, labels = get_graph_info("wc")
-    assert isinstance(nodes, int)
-    assert isinstance(edges, int)
-    assert isinstance(labels, list)
-    assert "a" in labels or "b" in labels  # примерная проверка
+    assert nodes == 332
+    assert edges == 269
+    assert labels == {"a", "d"}
 
 def test_create_and_save_two_cycled_graph():
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_simple_graph_funcs.py
+++ b/tests/test_simple_graph_funcs.py
@@ -5,11 +5,13 @@ import pydot
 from networkx.drawing import nx_pydot
 from project.simple_graph_funcs import get_graph_info, create_and_save_two_cycled_graph
 
+
 def test_get_graph_info():
     nodes, edges, labels = get_graph_info("wc")
     assert nodes == 332
     assert edges == 269
     assert labels == ["d", "a"]
+
 
 def test_create_and_save_two_cycled_graph():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -20,7 +22,7 @@ def test_create_and_save_two_cycled_graph():
         (pydot_graph,) = pydot.graph_from_dot_file(file_path)
         nodes = pydot_graph.get_nodes()
         edges = pydot_graph.get_edges()
-        labels = {edge.get_attributes().get('label', '') for edge in edges}
+        labels = {edge.get_attributes().get("label", "") for edge in edges}
 
         assert len(nodes) == 8
         assert len(edges) == 9

--- a/tests/test_simple_graph_funcs.py
+++ b/tests/test_simple_graph_funcs.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 import cfpq_data
+import pydot
+from networkx.drawing import nx_pydot
 from project.simple_graph_funcs import get_graph_info, create_and_save_two_cycled_graph
 
 def test_get_graph_info():
@@ -14,7 +16,12 @@ def test_create_and_save_two_cycled_graph():
         file_path = os.path.join(tmpdir, "graph.dot")
         create_and_save_two_cycled_graph(3, 4, ("x", "y"), file_path)
         assert os.path.exists(file_path)
-        with open(file_path) as f:
-            dot_content = f.read()
-        assert "x" in dot_content
-        assert "y" in dot_content
+
+        (pydot_graph,) = pydot.graph_from_dot_file(file_path)
+        nodes = pydot_graph.get_nodes()
+        edges = pydot_graph.get_edges()
+        labels = {edge.get_attributes().get('label', '') for edge in edges}
+
+        assert len(nodes) == 8
+        assert len(edges) == 9
+        assert labels == {"x", "y"}

--- a/tests/test_simple_graph_funcs.py
+++ b/tests/test_simple_graph_funcs.py
@@ -9,7 +9,7 @@ def test_get_graph_info():
     nodes, edges, labels = get_graph_info("wc")
     assert nodes == 332
     assert edges == 269
-    assert labels == {"a", "d"}
+    assert labels == ["d", "a"]
 
 def test_create_and_save_two_cycled_graph():
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_simple_graph_funcs.py
+++ b/tests/test_simple_graph_funcs.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+import cfpq_data
+from project.simple_graph_funcs import get_graph_info, create_and_save_two_cycled_graph
+
+def test_get_graph_info():
+    nodes, edges, labels = get_graph_info("wc")
+    assert isinstance(nodes, int)
+    assert isinstance(edges, int)
+    assert isinstance(labels, list)
+    assert "a" in labels or "b" in labels  # примерная проверка
+
+def test_create_and_save_two_cycled_graph():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = os.path.join(tmpdir, "graph.dot")
+        create_and_save_two_cycled_graph(3, 4, ("x", "y"), file_path)
+        assert os.path.exists(file_path)
+        with open(file_path) as f:
+            dot_content = f.read()
+        assert "x" in dot_content
+        assert "y" in dot_content

--- a/tests/test_simple_graph_funcs.py
+++ b/tests/test_simple_graph_funcs.py
@@ -1,8 +1,6 @@
 import os
 import tempfile
-import cfpq_data
 import pydot
-from networkx.drawing import nx_pydot
 from project.simple_graph_funcs import get_graph_info, create_and_save_two_cycled_graph
 
 


### PR DESCRIPTION
**ADD**:
- `simple_graph_funcs` module with 2 functions:
    - `get_graph_info` that returns number of nodes and edges, set of labels from a graph by a given file path.
    - `create_and_save_two_cycled_graph` that works similarly to [this](https://formallanguageconstrainedpathquerying.github.io/CFPQ_Data/reference/graphs/generated/cfpq_data.graphs.generators.labeled_two_cycles_graph.html#cfpq_data.graphs.generators.labeled_two_cycles_graph) function, but also saves resulting graph in a `pydot` file.
- simple tests for these functions

And initialized working environment for next tasks.